### PR TITLE
IGSS-101: Inject wifi credentials 

### DIFF
--- a/Device/Main.ino
+++ b/Device/Main.ino
@@ -7,6 +7,7 @@
 
 #include "config.h"
 #include "utility.h"
+#include "auth.h"
 #include "SystemTickCounter.h"
 
 static bool hasWifi = false;
@@ -20,7 +21,7 @@ static void InitWifi()
 {
   Screen.print(2, "Connecting...");
   
-  if (WiFi.begin() == WL_CONNECTED)
+  if (WiFi.begin(WIFI_USER, WIFI_PASS) == WL_CONNECTED)
   {
     IPAddress ip = WiFi.localIP();
     Screen.print(1, ip.get_address());

--- a/Device/auth.h
+++ b/Device/auth.h
@@ -4,7 +4,7 @@
 #ifndef IGSS_AUTH_H
 #define IGSS_AUTH_H
 
-#define WIFI_USER "wuser"
-#define WIFI_PASS "wpass"
+#define WIFI_USER ((char *)"wuser")
+#define WIFI_PASS ((const char *)"wpass")
 
 #endif /* IGSS_AUTH_H */

--- a/Device/auth.h
+++ b/Device/auth.h
@@ -1,0 +1,10 @@
+// Copyright (c) IGSS. All rights reserved.
+// Licensed under the MIT license. 
+
+#ifndef IGSS_AUTH_H
+#define IGSS_AUTH_H
+
+#define WIFI_USER "wuser"
+#define WIFI_PASS "wpass"
+
+#endif /* IGSS_AUTH_H */

--- a/README.md
+++ b/README.md
@@ -7,4 +7,17 @@
 
 For more info visit the [IoT DevKit](https://aka.ms/devkit) landing page.
 
+## Usage
+
+Make sure docker service is running on your machine and switch to the Device directory to get started.
+
+	cd Device
+
+Build the software
+
+	./build.sh
+
+Build and deploy software to mxchip
+
+	./build.sh -c {mxchip mount dir}
 


### PR DESCRIPTION
Use a header file for wifi credentials so it can be injected during the automated deployment process.