### PR TITLE
Adds writing of wifi-credentials and cleans up some code

### DIFF
--- a/Device/build.sh
+++ b/Device/build.sh
@@ -111,8 +111,6 @@ while [ "$1" != "" ]; do
     esac
 done
 
-
-
 setup_build_container() {
     build_build_container
     run_build_container
@@ -212,6 +210,7 @@ copy() {
 }
 
 trap exit_routine 0
+
 error() {
   local parent_lineno="$1"
   local message="$2"
@@ -223,6 +222,7 @@ error() {
   fi
   exit "${code}"
 }
+
 trap 'error ${LINENO}' ERR
 
 # Actual "main" part of the program


### PR DESCRIPTION
This MR implements the writing of WiFi credentials to `auth.h`.
Also, it implements the `cleanup` routine that can be used to remove all images.
In addition, it adds the `trap`, to do cleanup work on failure / exit of the script. This allows for better debug messages.