### PR TITLE
IGSS-101: Fail pipe on exit status fix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,5 @@ steps:
     echo Deploying branch `git rev-parse --abbrev-ref HEAD` at `git rev-parse HEAD`
     echo 'Changes:'
     git log --oneline -3
-    curl --user $C_USER $C_URL/build/`git rev-parse HEAD` 2>&1 | tee -a build.log
-    if grep -q "exit status 1" build.log; then exit 1; fi
+    curl -f --user $C_USER $C_URL/build/`git rev-parse HEAD` 2>&1
   displayName: 'Deploy to mxchip'
-


### PR DESCRIPTION
As stated here: https://github.com/iceguard/mxchip/pull/10#issuecomment-482694484,
it is possible to make curl fail when it receives a 4xx exit code.

Do this instead of having this tee and grep-magic.