### PR TITLE
IGSS-101: Removes the master trigger

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,9 +3,6 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
-trigger:
-- master
-
 variables:
 - group: mxchip
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,4 +15,4 @@ steps:
     echo 'Changes:'
     git log --oneline -3
     curl -f --user $C_USER $C_URL/build/`git rev-parse HEAD` 2>&1
-  displayName: 'Deploy to mxchip'
+  displayName: 'Build software (and deploy if master)'


### PR DESCRIPTION
The iot-cicd app has been updated to parse the branch and have master-specific arguments to call the buildscript with.
See [this](https://github.com/iceguard/iot-cicd/blob/0eefeca475fb656f9512caadb7542bfcd75ccb85/pkg/server/server.go#L189) part.

Now as we do not copy the software onto the devices on non-master branches anymore, we can safely call the pipeline on non-master branches too :sparkles: